### PR TITLE
ci: Fix pipenv cache location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,15 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Upgrade pip
-        run: |
-          # install pip=>20.1 to use "pip cache dir"
-          python3 -m pip install --upgrade pip
-          python3 -m pip -V
-
-      - name: Get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
       - name: Cache dependencies
         uses: actions/cache@v1
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
+          path: ~/.cache/pipenv
           key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pipenv-
 
+      - run: python3 -m pip install --upgrade pip
       - run: python3 -m pip install pipenv
       - run: pipenv sync --dev
       - run: pipenv run mkdocs build --config-file ./mkdocs-sample.yml

--- a/docs_sample/hosting-and-deployment/github-pages.md
+++ b/docs_sample/hosting-and-deployment/github-pages.md
@@ -8,6 +8,8 @@
 
 - [peaceiris/actions-gh-pages: GitHub Actions for deploying to GitHub Pages with Static Site Generators](https://github.com/peaceiris/actions-gh-pages)
 
+Go to the repository and read the latest `README.md` for more details.
+
 
 
 ## Build and deploy with `mkdocs gh-deploy`


### PR DESCRIPTION
The cache location of pipenv on Linux is `~/.cache/pipenv`, not `~/.cache/pip`.

Fix #102