### PR TITLE
Revert "deps: bump pymdown-extensions from 8.2 to 9.6"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ mkdocs==1.2.1
 packaging==20.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 prompt-toolkit==3.0.18
 pygments==2.9.0
-pymdown-extensions==9.6; python_version >= '3.6'
+pymdown-extensions==8.2; python_version >= '3.6'
 pyparsing==3.0.0b2; python_version >= '3.5'
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-markdown-math==0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mkdocs==1.3.0
 packaging==21.3; python_version >= '3.6'
 prompt-toolkit==3.0.29
 pygments==2.11.2
-pymdown-extensions==9.6; python_version >= '3.7'
+pymdown-extensions==9.3; python_version >= '3.7'
 pyparsing==3.0.8; python_full_version >= '3.6.8'
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 python-markdown-math==0.8


### PR DESCRIPTION
Reverts peaceiris/mkdocs-material-boilerplate#321