### PR TITLE
Revert "deps: bump watchdog from 2.1.2 to 2.1.9"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,6 @@ python-markdown-math==0.8
 pyyaml-env-tag==0.1; python_version >= '3.6'
 pyyaml==5.4.1
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-watchdog==2.1.9; python_version >= '3.6'
+watchdog==2.1.2; python_version >= '3.6'
 wcwidth==0.2.5
 zipp==3.9.0; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ python-markdown-math==0.8
 pyyaml-env-tag==0.1; python_version >= '3.6'
 pyyaml==6.0
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-watchdog==2.1.9; python_version >= '3.6'
+watchdog==2.1.7; python_version >= '3.6'
 wcwidth==0.2.5
 zipp==3.9.0; python_version >= '3.7'


### PR DESCRIPTION
Reverts peaceiris/mkdocs-material-boilerplate#317